### PR TITLE
Closes #39 Fix data validation pipeline handling of Unicode characters in metadata fields

### DIFF
--- a/__proto5/BasicTeamSorterTests.cs
+++ b/__proto5/BasicTeamSorterTests.cs
@@ -1,0 +1,83 @@
+using Algorithms.Sorters.Comparison;
+
+namespace Algorithms.Tests.Sorters.Comparison
+{
+    [TestFixture]
+    public class BasicTimSorterTests
+    {
+        private readonly BasicTimSorter<int> sorter = new(Comparer<int>.Default);
+
+        [Test]
+        public void Sort_EmptyArray_DoesNotThrow()
+        {
+            var array = Array.Empty<int>();
+            Assert.DoesNotThrow(() => sorter.Sort(array));
+            Assert.That(array, Is.Empty);
+        }
+
+        [Test]
+        public void Sort_SingleElementArray_DoesNotChangeArray()
+        {
+            var array = new[] { 1 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1 }));
+        }
+
+        [Test]
+        public void Sort_AlreadySortedArray_DoesNotChangeArray()
+        {
+            var array = new[] { 1, 2, 3, 4, 5 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void Sort_UnsortedArray_SortsCorrectly()
+        {
+            var array = new[] { 5, 3, 1, 4, 2 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void Sort_ReverseSortedArray_SortsCorrectly()
+        {
+            var array = new[] { 5, 4, 3, 2, 1 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void Sort_ArrayWithDuplicates_SortsCorrectly()
+        {
+            var array = new[] { 3, 1, 2, 3, 1, 2 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 1, 2, 2, 3, 3 }));
+        }
+
+        [Test]
+        public void Sort_LargeArray_SortsCorrectly()
+        {
+            var array = new int[1000];
+            for (var i = 0; i < 1000; i++)
+            {
+                array[i] = 1000 - i;
+            }
+            sorter.Sort(array);
+            array.Should().BeInAscendingOrder();
+        }
+
+        [Test]
+        public void Sort_LargeRandomArray_SortsCorrectly()
+        {
+            var array = new int[1000];
+            var random = new Random();
+            for (var i = 0; i < 1000; i++)
+            {
+                array[i] = random.Next(1, 1001);
+            }
+            sorter.Sort(array);
+            array.Should().BeInAscendingOrder();
+        }
+    }
+}

--- a/__proto5/stack.ex
+++ b/__proto5/stack.ex
@@ -1,0 +1,122 @@
+defmodule Algorithms.DataStructures.Stack do
+  @moduledoc """
+  Stack implementation in Elixir. A stack is like a list,
+  but with only LIFO (last-in, first-out) functions. An abstract
+  stack is similar to a stack of items in real life. Whatever
+  goes on last must come off first.
+
+  ## Reference: https://computersciencewiki.org/index.php/Stack
+  ## Author: Ian Cowan (https://github.com/iccowan)
+  """
+
+  defstruct stack: []
+
+  @typedoc """
+  This simple stack implementation simply uses a list. Although
+  elixir will allow you to have any number of different types in
+  the list, it is generally good practice to only push one type
+  of data per stack.
+  """
+  @type t :: %__MODULE__{
+          stack: list()
+        }
+
+  alias Algorithms.DataStructures.Stack
+
+  @doc """
+  Pushes a given `val` to the stack
+
+  Returns `{:ok, val, %Stack{}}`
+
+  ## Examples
+
+    iex> Algorithms.DataStructures.Stack.push(stack, 1)
+    {:ok, 1, %Algorithms.DataStructures.Stack{stack: [1]}}
+
+  """
+  def push(stack = %Stack{stack: stack_list}, val) do
+    stack = %Stack{
+      stack
+      | stack: [val | stack_list]
+    }
+
+    {:ok, val, stack}
+  end
+
+  @doc """
+  Retrieves the value on the top of the stack without removing it
+
+  Returns `{:ok | :error, top_val | binary(), %Stack{}}`
+
+  ## Examples
+
+    iex> stack = %Algorithms.DataStructures.Stack{stack: [1]}
+    iex> Algorithms.DataStructures.Stack.peek(stack)
+    {:ok, 1, %Algorithms.DataStructures.Stack{stack: [1]}}
+
+    iex> stack = %Algorithms.DataStructures.Stack{}
+    iex> Algorithms.DataStructures.Stack.peek(stack)
+    {:error, "Empty stack", %Algorithms.DataStructures.Stack{stack: []}}
+
+  """
+  def peek(stack = %Stack{stack: []}) do
+    {:error, "Empty stack", stack}
+  end
+
+  def peek(stack = %Stack{stack: [val | _stack_list]}) do
+    {:ok, val, stack}
+  end
+
+  @doc """
+  Retrieves the value on the top of the stack and removes it
+
+  Returns `{:ok | :error, top_val | binary(), %Stack{}}`
+
+  ## Examples
+
+    iex> stack = %Algorithms.DataStructures.Stack{stack: [1]}
+    iex> Algorithms.DataStructures.Stack.pop(stack)
+    {:ok, 1, %Algorithms.DataStructures.Stack{stack: []}}
+
+    iex> stack = %Algorithms.DataStructures.Stack{}
+    iex> Algorithms.DataStructures.Stack.pop(stack)
+    {:error, "Empty stack", %Algorithms.DataStructures.Stack{stack: []}}
+
+  """
+  def pop(stack = %Stack{stack: []}) do
+    {:error, "Empty stack", stack}
+  end
+
+  def pop(stack = %Stack{stack: [val | stack_list]}) do
+    stack = %Stack{
+      stack
+      | stack: stack_list
+    }
+
+    {:ok, val, stack}
+  end
+
+  @doc """
+  Checks if a stack is empty or not
+
+  Returns `{:ok, boolean(), %Stack{}}`
+
+  ## Examples
+
+    iex> stack = %Algorithms.DataStructures.Stack{stack: [1]}
+    iex> Algorithms.DataStructures.Stack.is_empty(stack)
+    {:ok, false, %Algorithms.DataStructures.Stack{stack: [1]}}
+
+    iex> stack = %Algorithms.DataStructures.Stack{}
+    iex> Algorithms.DataStructures.Stack.is_empty(stack)
+    {:ok, true, %Algorithms.DataStructures.Stack{stack: []}}
+
+  """
+  def is_empty(stack = %Stack{stack: []}) do
+    {:ok, true, stack}
+  end
+
+  def is_empty(stack = %Stack{stack: _stackList}) do
+    {:ok, false, stack}
+  end
+end


### PR DESCRIPTION
39 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.