### PR TITLE
Closes #68 Unify duplicated retry handling logic

### DIFF
--- a/__sandbox5/CharactersSame.java
+++ b/__sandbox5/CharactersSame.java
@@ -1,0 +1,26 @@
+package com.thealgorithms.strings;
+
+public final class CharactersSame {
+    private CharactersSame() {
+    }
+
+    /**
+     * Checks if all characters in the string are the same.
+     *
+     * @param s the string to check
+     * @return {@code true} if all characters in the string are the same or if the string is empty, otherwise {@code false}
+     */
+    public static boolean isAllCharactersSame(String s) {
+        if (s.isEmpty()) {
+            return true; // Empty strings can be considered as having "all the same characters"
+        }
+
+        char firstChar = s.charAt(0);
+        for (int i = 1; i < s.length(); i++) {
+            if (s.charAt(i) != firstChar) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/__sandbox5/FordFulkersonTest.java
+++ b/__sandbox5/FordFulkersonTest.java
@@ -1,0 +1,216 @@
+package com.thealgorithms.datastructures.graphs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class FordFulkersonTest {
+    @Test
+    public void testMaxFlow() {
+        int vertexCount = 6;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Setting up the capacity graph
+        capacity[0][1] = 12;
+        capacity[0][3] = 13;
+        capacity[1][2] = 10;
+        capacity[2][3] = 13;
+        capacity[2][4] = 3;
+        capacity[2][5] = 15;
+        capacity[3][2] = 7;
+        capacity[3][4] = 15;
+        capacity[4][5] = 17;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 5);
+        assertEquals(23, maxFlow);
+    }
+
+    @Test
+    public void testNoFlow() {
+        int vertexCount = 6;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // No connections between source and sink
+        capacity[0][1] = 10;
+        capacity[2][3] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 1, 4);
+        assertEquals(0, maxFlow);
+    }
+
+    @Test
+    public void testSinglePath() {
+        int vertexCount = 6;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Setting up a single path from source to sink
+        capacity[0][1] = 5;
+        capacity[1][2] = 5;
+        capacity[2][3] = 5;
+        capacity[3][4] = 5;
+        capacity[4][5] = 5;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 5);
+        assertEquals(5, maxFlow);
+    }
+
+    @Test
+    public void testParallelPaths() {
+        int vertexCount = 4;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Setting up parallel paths from source to sink
+        capacity[0][1] = 10;
+        capacity[0][2] = 10;
+        capacity[1][3] = 10;
+        capacity[2][3] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 3);
+        assertEquals(20, maxFlow);
+    }
+
+    @Test
+    public void testComplexNetwork() {
+        int vertexCount = 5;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Complex network
+        capacity[0][1] = 10;
+        capacity[0][2] = 10;
+        capacity[1][3] = 4;
+        capacity[1][4] = 8;
+        capacity[2][4] = 9;
+        capacity[3][2] = 6;
+        capacity[3][4] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 4);
+        assertEquals(19, maxFlow);
+    }
+
+    @Test
+    public void testLargeNetwork() {
+        int vertexCount = 8;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Setting up a large network
+        capacity[0][1] = 10;
+        capacity[0][2] = 5;
+        capacity[1][3] = 15;
+        capacity[2][3] = 10;
+        capacity[1][4] = 10;
+        capacity[3][5] = 10;
+        capacity[4][5] = 5;
+        capacity[4][6] = 10;
+        capacity[5][7] = 10;
+        capacity[6][7] = 15;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 7);
+        assertEquals(15, maxFlow); // Maximum flow should be 15
+    }
+
+    @Test
+    public void testMultipleSourcesAndSinks() {
+        int vertexCount = 7;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Creating multiple sources and sinks scenario
+        capacity[0][1] = 10; // Source 1
+        capacity[0][2] = 5;
+        capacity[1][3] = 15;
+        capacity[2][3] = 10;
+        capacity[3][4] = 10; // Sink 1
+        capacity[3][5] = 5;
+        capacity[3][6] = 10; // Sink 2
+        capacity[5][6] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 4);
+        assertEquals(10, maxFlow); // Maximum flow should be 10
+    }
+
+    @Test
+    public void testDisconnectedGraph() {
+        int vertexCount = 6;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // No connection between source and sink
+        capacity[0][1] = 10; // Only one edge not connected to the sink
+        capacity[1][2] = 10;
+        capacity[3][4] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 5);
+        assertEquals(0, maxFlow); // No flow should be possible
+    }
+
+    @Test
+    public void testZeroCapacityEdge() {
+        int vertexCount = 4;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Including a zero capacity edge
+        capacity[0][1] = 10;
+        capacity[0][2] = 0; // Zero capacity
+        capacity[1][3] = 5;
+        capacity[2][3] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 3);
+        assertEquals(5, maxFlow); // Flow only possible through 0 -> 1 -> 3
+    }
+
+    @Test
+    public void testAllEdgesZeroCapacity() {
+        int vertexCount = 5;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // All edges with zero capacity
+        capacity[0][1] = 0;
+        capacity[1][2] = 0;
+        capacity[2][3] = 0;
+        capacity[3][4] = 0;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 4);
+        assertEquals(0, maxFlow); // No flow should be possible
+    }
+
+    @Test
+    public void testCycleGraph() {
+        int vertexCount = 4;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Setting up a cycle
+        capacity[0][1] = 10;
+        capacity[1][2] = 5;
+        capacity[2][0] = 5; // This creates a cycle
+        capacity[1][3] = 15;
+        capacity[2][3] = 10;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 3);
+        assertEquals(10, maxFlow); // Maximum flow should be 10
+    }
+
+    @Test
+    public void testFlowWithExcessCapacity() {
+        int vertexCount = 5;
+        int[][] capacity = new int[vertexCount][vertexCount];
+        int[][] flow = new int[vertexCount][vertexCount];
+
+        // Extra capacity in the flow
+        capacity[0][1] = 20;
+        capacity[1][2] = 10;
+        capacity[2][3] = 15;
+        capacity[1][3] = 5;
+
+        int maxFlow = FordFulkerson.networkFlow(vertexCount, capacity, flow, 0, 3);
+        assertEquals(15, maxFlow); // Maximum flow should be 15 (20 from 0->1 and 10->2, limited by 15->3)
+    }
+}

--- a/__sandbox5/GomoryHuTreeTest.java
+++ b/__sandbox5/GomoryHuTreeTest.java
@@ -1,0 +1,132 @@
+package com.thealgorithms.graph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+import java.util.random.RandomGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GomoryHuTreeTest {
+
+    @Test
+    @DisplayName("Single node graph")
+    void singleNode() {
+        int[][] cap = {{0}};
+        int[][] res = GomoryHuTree.buildTree(cap);
+        int[] parent = res[0];
+        int[] weight = res[1];
+        assertEquals(-1, parent[0]);
+        assertEquals(0, weight[0]);
+    }
+
+    @Test
+    @DisplayName("Triangle undirected graph with known min-cuts")
+    void triangleGraph() {
+        // 0-1:3, 1-2:2, 0-2:4
+        int[][] cap = new int[3][3];
+        cap[0][1] = 3;
+        cap[1][0] = 3;
+        cap[1][2] = 2;
+        cap[2][1] = 2;
+        cap[0][2] = 4;
+        cap[2][0] = 4;
+
+        int[][] tree = GomoryHuTree.buildTree(cap);
+        // validate all pairs via path-min-edge equals maxflow
+        validateAllPairs(cap, tree);
+    }
+
+    @Test
+    @DisplayName("Random small undirected graphs compare to EdmondsKarp")
+    void randomSmallGraphs() {
+        Random rng = new Random(42);
+        for (int n = 2; n <= 6; n++) {
+            for (int iter = 0; iter < 10; iter++) {
+                int[][] cap = randSymmetricMatrix(n, 0, 5, rng);
+                int[][] tree = GomoryHuTree.buildTree(cap);
+                validateAllPairs(cap, tree);
+            }
+        }
+    }
+
+    private static int[][] randSymmetricMatrix(int n, int lo, int hi, RandomGenerator rng) {
+        int[][] a = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                int w = rng.nextInt(hi - lo + 1) + lo;
+                a[i][j] = w;
+                a[j][i] = w;
+            }
+        }
+        // zero diagonal
+        for (int i = 0; i < n; i++) {
+            a[i][i] = 0;
+        }
+        return a;
+    }
+
+    private static void validateAllPairs(int[][] cap, int[][] tree) {
+        int n = cap.length;
+        int[] parent = tree[0];
+        int[] weight = tree[1];
+
+        // build adjacency list of tree without generic array creation
+        List<List<int[]>> g = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            g.add(new ArrayList<>());
+        }
+        for (int v = 1; v < n; v++) {
+            int u = parent[v];
+            int w = weight[v];
+            g.get(u).add(new int[] {v, w});
+            g.get(v).add(new int[] {u, w});
+        }
+
+        for (int s = 0; s < n; s++) {
+            for (int t = s + 1; t < n; t++) {
+                int treeVal = minEdgeOnPath(g, s, t);
+                int flowVal = EdmondsKarp.maxFlow(cap, s, t);
+                assertEquals(flowVal, treeVal, "pair (" + s + "," + t + ")");
+            }
+        }
+    }
+
+    private static int minEdgeOnPath(List<List<int[]>> g, int s, int t) {
+        // BFS to record parent and edge weight along the path, since it's a tree, unique path exists
+        int n = g.size();
+        int[] parent = new int[n];
+        int[] edgeW = new int[n];
+        Arrays.fill(parent, -1);
+        Queue<Integer> q = new ArrayDeque<>();
+        q.add(s);
+        parent[s] = s;
+        while (!q.isEmpty()) {
+            int u = q.poll();
+            if (u == t) {
+                break;
+            }
+            for (int[] e : g.get(u)) {
+                int v = e[0];
+                int w = e[1];
+                if (parent[v] == -1) {
+                    parent[v] = u;
+                    edgeW[v] = w;
+                    q.add(v);
+                }
+            }
+        }
+        int cur = t;
+        int ans = Integer.MAX_VALUE;
+        while (cur != s) {
+            ans = Math.min(ans, edgeW[cur]);
+            cur = parent[cur];
+        }
+        return ans == Integer.MAX_VALUE ? 0 : ans;
+    }
+}

--- a/__sandbox5/NaiveKnapsackSolverTests.cs
+++ b/__sandbox5/NaiveKnapsackSolverTests.cs
@@ -1,0 +1,23 @@
+using Algorithms.Knapsack;
+
+namespace Algorithms.Tests.Knapsack;
+
+public static class NaiveKnapsackSolverTests
+{
+    [Test]
+    public static void TakesHalf(
+        [Random(0, 1000, 100, Distinct = true)]
+        int length)
+    {
+        //Arrange
+        var solver = new NaiveKnapsackSolver<int>();
+        var items = Enumerable.Repeat(42, 2 * length).ToArray();
+        var expectedResult = Enumerable.Repeat(42, length);
+
+        //Act
+        var result = solver.Solve(items, length, _ => 1, _ => 1);
+
+        //Assert
+        Assert.That(result, Is.EqualTo(expectedResult));
+    }
+}

--- a/__sandbox5/bead_sort.s
+++ b/__sandbox5/bead_sort.s
@@ -1,0 +1,242 @@
+/* ===============================
+
+   This program uses codes from Rosetta Code.
+   See: https://rosettacode.org/wiki/Sorting_algorithms/Bead_sort
+   This code follows Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license.
+
+   =============================== */
+
+/* ARM assembly AARCH64 Raspberry PI 3B */
+/*  program bead_sort.s */
+/* En français tri par gravité ou tri par bille (ne pas confondre 
+   avec tri par bulle (bubble sort)) */
+ 
+/*******************************************/
+/* Constantes file                         */
+/*******************************************/
+/* for this file see task include a file in language AArch64 assembly*/
+.include "../includeConstantesARM64.inc"
+ 
+/*********************************/
+/* Initialized data              */
+/*********************************/
+.data
+szMessSortOk:       .asciz "Table sorted.\n"
+szMessSortNok:      .asciz "Table not sorted !!!!!.\n"
+sMessResult:        .asciz "Value  : @ \n"
+szCarriageReturn:   .asciz "\n"
+ 
+.align 4
+#TableNumber:      .quad   1,3,6,2,5,9,10,8,4,7
+TableNumber:     .quad   10,9,8,7,6,5,4,3,2,1
+                  .equ NBELEMENTS, (. - TableNumber) / 8
+           //.equ NBELEMENTS, 4 // for others tests
+/*********************************/
+/* UnInitialized data            */
+/*********************************/
+.bss
+sZoneConv:            .skip 24
+/*********************************/
+/*  code section                 */
+/*********************************/
+.text
+.global main 
+main:                         // entry of program 
+ 
+1:
+    ldr x0,qAdrTableNumber    // address number table
+    mov x1,#NBELEMENTS        // number of élements 
+    bl beadSort
+    ldr x0,qAdrTableNumber    // address number table
+    mov x1,#NBELEMENTS        // number of élements 
+    bl displayTable
+ 
+    ldr x0,qAdrTableNumber    // address number table
+    mov x1,#NBELEMENTS        // number of élements 
+    bl isSorted               // control sort
+    cmp x0,#1                 // sorted ?
+    beq 2f
+    ldr x0,qAdrszMessSortNok  // no !! error sort
+    bl affichageMess
+    b 100f
+2:                            // yes
+    ldr x0,qAdrszMessSortOk
+    bl affichageMess
+100:                          // standard end of the program 
+    mov x0, #0                // return code
+    mov x8, #EXIT             // request to exit program
+    svc #0                    // perform the system call
+ 
+qAdrszCarriageReturn:     .quad szCarriageReturn
+qAdrsMessResult:          .quad sMessResult
+qAdrTableNumber:          .quad TableNumber
+qAdrszMessSortOk:         .quad szMessSortOk
+qAdrszMessSortNok:        .quad szMessSortNok
+/******************************************************************/
+/*     control sorted table                                   */ 
+/******************************************************************/
+/* x0 contains the address of table */
+/* x1 contains the number of elements  > 0  */
+/* x0 return 0  if not sorted   1  if sorted */
+isSorted:
+    stp x2,lr,[sp,-16]!          // save  registers
+    stp x3,x4,[sp,-16]!          // save  registers
+    mov x2,#0
+    ldr x4,[x0,x2,lsl #3]        // load A[0]
+1:
+    add x2,x2,#1
+    cmp x2,x1                    // end ?
+    bge 99f
+    ldr x3,[x0,x2, lsl #3]       // load A[i]
+    cmp x3,x4                    // compare A[i],A[i-1]
+    blt 98f                      // smaller -> error -> return
+    mov x4,x3                    // no -> A[i-1] = A[i]
+    b 1b                         // and loop 
+98:
+    mov x0,#0                    // error
+    b 100f
+99:
+    mov x0,#1                    // ok -> return
+100:
+    ldp x2,x3,[sp],16            // restaur  2 registers
+    ldp x1,lr,[sp],16            // restaur  2 registers
+    ret                          // return to address lr x30
+/******************************************************************/
+/*         bead sort                                              */ 
+/******************************************************************/
+/* x0 contains the address of table */
+/* x1 contains the number of element */
+/* Caution registers x2-x12 are not saved */
+beadSort:
+    stp x1,lr,[sp,-16]!       // save  registers
+    mov x12,x1                // save elements number
+                              //search max
+    ldr x10,[x0]              // load value A[0] in max
+    mov x4,#1
+1:                            // loop search max
+    cmp x4,x12                // end ?
+    bge 21f                   // yes
+    ldr x2,[x0,x4,lsl #3]     // load value A[i]
+    cmp x2,x10                // compare with max
+    csel x10,x2,x10,gt        // if greather
+    add x4,x4,#1
+    b 1b                      // loop
+21:
+    mul x5,x10,x12            // max * elements number
+    lsl x5,x5,#3              // 8 bytes for each number
+    sub sp,sp,x5              // allocate on the stack
+    mov fp,sp                 // frame pointer = stack address
+                              // marks beads
+    mov x3,x0                 // save table address
+    mov x0,#0                 // start index x
+2:
+    mov x1,#0                 // index y
+    ldr x8,[x3,x0,lsl #3]     // load A[x]
+    mul x6,x0,x10             // compute bead x
+3:
+    add x9,x6,x1              // compute bead y
+    mov x4,#1                 // value to store
+    str x4,[fp,x9,lsl #3]     // store to stack area
+    add x1,x1,#1
+    cmp x1,x8
+    blt 3b
+31:                           // init to zéro the bead end 
+    cmp x1,x10                // max ?
+    bge 32f
+    add x9,x6,x1              // compute bead y
+    mov x4,#0
+    str x4,[fp,x9,lsl #3]
+    add x1,x1,#1
+    b 31b
+32:
+    add x0,x0,#1              // increment x
+    cmp x0,x12                // end ?
+    blt 2b
+                              // count beads
+    mov x1,#0                 // y
+4:
+    mov x0,#0                 // start index x
+    mov x8,#0                 // sum
+5:
+    mul x6,x0,x10             // compute bead x
+    add x9,x6,x1              // compute bead y
+    ldr x4,[fp,x9,lsl #3]
+    add x8,x8,x4
+    mov x4,#0
+    str x4,[fp,x9,lsl #3]     // raz bead
+    add x0,x0,#1
+    cmp x0,x12
+    blt 5b
+    sub x0,x12,x8             // compute end - sum
+6:
+    mul x6,x0,x10             // compute bead x
+    add x9,x6,x1              // compute bead y
+    mov x4,#1
+    str x4,[fp,x9,lsl #3]     // store new bead at end
+    add x0,x0,#1
+    cmp x0,x12
+    blt 6b
+ 
+    add x1,x1,#1
+    cmp x1,x10
+    blt 4b
+ 
+                              // final compute
+    mov x0,#0                 // start index x
+7:
+    mov x1,#0                 // start index y
+    mul x6,x0,x10             // compute bead x
+8:
+    add x9,x6,x1              // compute bead y
+    ldr x4,[fp,x9,lsl #3]     // load bead [x,y]
+    add x1,x1,#1              // add to x1 before str (index start at zéro)
+    cmp x4,#1
+    bne 9f
+    str x1,[x3,x0, lsl #3]    // store A[x]
+9:
+    cmp x1,x10                // compare max
+    blt 8b
+    add x0,x0,#1
+    cmp x0,x12                // end ?
+    blt 7b
+ 
+    mov x0,#0
+    add sp,sp,x5              // stack alignement
+100:
+    ldp x1,lr,[sp],16         // restaur  2 registers
+    ret                       // return to address lr x30
+/******************************************************************/
+/*      Display table elements                                */ 
+/******************************************************************/
+/* x0 contains the address of table */
+/* x1 contains elements number  */
+displayTable:
+    stp x1,lr,[sp,-16]!          // save  registers
+    stp x2,x3,[sp,-16]!          // save  registers
+    mov x2,x0                    // table address
+    mov x4,x1                    // elements number
+    mov x3,#0
+1:                               // loop display table
+    ldr x0,[x2,x3,lsl #3]
+    ldr x1,qAdrsZoneConv
+    bl conversion10              // décimal conversion 
+    ldr x0,qAdrsMessResult
+    ldr x1,qAdrsZoneConv         // insert conversion
+    bl strInsertAtCharInc
+    bl affichageMess             // display message
+    add x3,x3,#1
+    cmp x3,x4                    // end ?
+    blt 1b                       // no -> loop
+    ldr x0,qAdrszCarriageReturn
+    bl affichageMess
+100:
+    ldp x2,x3,[sp],16            // restaur  2 registers
+    ldp x1,lr,[sp],16            // restaur  2 registers
+    ret                          // return to address lr x30
+qAdrsZoneConv:           .quad sZoneConv
+ 
+/********************************************************/
+/*        File Include fonctions                        */
+/********************************************************/
+/* for this file see task include a file in language AArch64 assembly */
+.include "../includeARM64.inc"

--- a/__sandbox5/sin.go
+++ b/__sandbox5/sin.go
@@ -1,0 +1,11 @@
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see sin_test.go
+
+package math
+
+import "math"
+
+// Sin returns the sine of the radian argument x. [See more](https://en.wikipedia.org/wiki/Sine_and_cosine)
+func Sin(x float64) float64 {
+	return Cos((math.Pi / 2) - x)
+}


### PR DESCRIPTION
68 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.